### PR TITLE
Added OS X platform.

### DIFF
--- a/Specs/Alamofire/1.1.3/Alamofire.podspec.json
+++ b/Specs/Alamofire/1.1.3/Alamofire.podspec.json
@@ -13,7 +13,8 @@
     "tag": "1.1.3"
   },
   "platforms": {
-    "ios": "8.0"
+    "ios": "8.0",
+    "osx": "10.9"
   },
   "source_files": "Source/*.swift",
   "requires_arc": true


### PR DESCRIPTION
Alamofire deployment OS X target is already 10.9 in 1.1.3 release available on the Alamofire github.
